### PR TITLE
DATA-3189 - Add POST endpoints. Add upload file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+* Add support for POST request endpoints.
+* Refactor exception handling such that exceptions are no longer nested classes of the factory. _This is a breaking change._
+
 ## 0.1.0
 * Initial version of the client.
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,25 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.jwplayer</groupId>
   <artifactId>jwplatform</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
 </dependency>
 ```
 
 ## Usage
 
-The following is an example of how to use the client.
+The following is an example of how to use the client for a video of sourcetype `url`:
 
 ```java
 
 import com.jwplayer.jwplatform.JWPlatformClient;
 import com.jwplayer.jwplatform.exception.JWPlatformException;
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONObject;
 
 public class JWPlatformClientExample {
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         String apiKey = "key";
         String apiSecret = "secret";
 
@@ -55,7 +58,7 @@ public class JWPlatformClientExample {
             System.out.println(videosCreateResponse);
             
             // Show the properties of the created video
-            String videoKey = videosCreateResponse.getJSONObject("video").get("key").toString();
+            String videoKey = videosCreateResponse.getJSONObject("video").getString("key");
             Map<String, String> videosShowParams = new HashMap<>();
             videosShowParams.put("video_key", videoKey);
             JSONObject videosShowResponse = client.request(videosShowPath, videosShowParams);
@@ -66,6 +69,45 @@ public class JWPlatformClientExample {
     }
 }
 
+```
+
+The following is an example of how to use the client for a video of sourcetype `file`:
+
+```java
+
+import com.jwplayer.jwplatform.JWPlatformClient;
+import com.jwplayer.jwplatform.exception.JWPlatformException;
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONObject;
+
+public class JWPlatformClientExample {
+
+    public static void main(String[] args) {
+    String apiKey = "key";
+    String apiSecret = "secret";
+
+    String videosCreatePath = "videos/create";
+    Map<String, String> videosCreateParams = new HashMap<>();
+    videosCreateParams.put("sourcetype", "file");
+    videosCreateParams.put("title", "Some Video Title");
+
+    String localFilePath = "/some/path//test_video.mp4";
+
+    try {
+        JWPlatformClient client = JWPlatformClient.create(apiKey, apiSecret);
+
+        // Create a video asset
+        JSONObject videosCreateResponse = client.request(videosCreatePath, videosCreateParams);
+        System.out.println(videosCreateResponse);
+
+        // Upload the video from local file system
+        JSONObject videoUploadResponse = client.upload(videosCreateResponse, localFilePath);
+        System.out.println(videoUploadResponse);
+    } catch (JWPlatformException e) {
+        e.printStackTrace();
+    }
+}
 ```
 
 ## Supported operations

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.jwplayer</groupId>
     <artifactId>jwplatform</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <name>JWPlatform-Java</name>

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformApiKeyInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyMissingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformApiKeyMissingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallFailedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallFailedException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformCallFailedException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformCallInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallUnavailableException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallUnavailableException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformCallUnavailableException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDatabaseException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDatabaseException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformDatabaseException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformDigestInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestMissingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformDigestMissingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformFileSizeInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeMissingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformFileSizeMissingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileUploadFailedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileUploadFailedException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformFileUploadFailedException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformIntegrityException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformIntegrityException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformIntegrityException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformInternalException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformInternalException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformInternalException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformItemAlreadyExistsException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformItemAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformItemAlreadyExistsException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNoMethodException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNoMethodException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformNoMethodException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNonceInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNonceInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformNonceInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotFoundException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotFoundException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformNotFoundException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotImplementedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotImplementedException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformNotImplementedException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotSupportedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotSupportedException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformNotSupportedException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEmptyException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEmptyException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformParameterEmptyException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEncodingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEncodingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformParameterEncodingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformParameterInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterMissingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformParameterMissingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPermissionDeniedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPermissionDeniedException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformPermissionDeniedException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPreconditionFailedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPreconditionFailedException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformPreconditionFailedException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformRateLimitExceededException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformRateLimitExceededException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformRateLimitExceededException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformSignatureInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureMissingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformSignatureMissingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampInvalidException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformTimestampInvalidException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampMissingException.java
@@ -1,0 +1,4 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformTimestampMissingException extends JWPlatformException {
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformUnknownException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformUnknownException.java
@@ -1,0 +1,16 @@
+package com.jwplayer.jwplatform.exception;
+
+public class JWPlatformUnknownException extends JWPlatformException {
+
+    public JWPlatformUnknownException(){
+    }
+
+    /**
+     * Instance of an UnknownException.
+     *
+     * @param message the exception message
+     */
+    public JWPlatformUnknownException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jwplayer/jwplatform/exception/MediaAPIExceptionFactory.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/MediaAPIExceptionFactory.java
@@ -7,37 +7,37 @@ import java.util.Map;
 public class MediaAPIExceptionFactory {
 
   private static final Map<String, JWPlatformException> exceptions = ImmutableMap.<String, JWPlatformException>builder()
-          .put("Unknown", new MediaAPIExceptionFactory.JWPlatformUnknownException())
-          .put("NotFound", new MediaAPIExceptionFactory.JWPlatformNotFoundException())
-          .put("NoMethod", new MediaAPIExceptionFactory.JWPlatformNoMethodException())
-          .put("NotImplemented", new MediaAPIExceptionFactory.JWPlatformNotImplementedException())
-          .put("NotSupported", new MediaAPIExceptionFactory.JWPlatformNotSupportedException())
-          .put("CallFailed", new MediaAPIExceptionFactory.JWPlatformCallFailedException())
-          .put("CallUnavailable", new MediaAPIExceptionFactory.JWPlatformCallUnavailableException())
-          .put("CallInvalid", new MediaAPIExceptionFactory.JWPlatformCallInvalidException())
-          .put("ParameterMissing", new MediaAPIExceptionFactory.JWPlatformParameterMissingException())
-          .put("ParameterEmpty", new MediaAPIExceptionFactory.JWPlatformParameterEmptyException())
-          .put("ParameterEncoding", new MediaAPIExceptionFactory.JWPlatformParameterEncodingException())
-          .put("ParameterInvalid", new MediaAPIExceptionFactory.JWPlatformParameterInvalidException())
-          .put("PreconditionFailed", new MediaAPIExceptionFactory.JWPlatformPreconditionFailedException())
-          .put("ItemAlreadyExists", new MediaAPIExceptionFactory.JWPlatformItemAlreadyExistsException())
-          .put("PermissionDenied", new MediaAPIExceptionFactory.JWPlatformPermissionDeniedException())
-          .put("Database", new MediaAPIExceptionFactory.JWPlatformDatabaseException())
-          .put("Integrity", new MediaAPIExceptionFactory.JWPlatformIntegrityException())
-          .put("DigestMissing", new MediaAPIExceptionFactory.JWPlatformDigestMissingException())
-          .put("DigestInvalid", new MediaAPIExceptionFactory.JWPlatformDigestInvalidException())
-          .put("FileUploadFailed", new MediaAPIExceptionFactory.JWPlatformFileUploadFailedException())
-          .put("FileSizeMissing", new MediaAPIExceptionFactory.JWPlatformFileSizeMissingException())
-          .put("FileSizeInvalid", new MediaAPIExceptionFactory.JWPlatformFileSizeInvalidException())
-          .put("Internal", new MediaAPIExceptionFactory.JWPlatformInternalException())
-          .put("ApiKeyMissing", new MediaAPIExceptionFactory.JWPlatformApiKeyMissingException())
-          .put("ApiKeyInvalid", new MediaAPIExceptionFactory.JWPlatformApiKeyInvalidException())
-          .put("TimestampMissing", new MediaAPIExceptionFactory.JWPlatformTimestampMissingException())
-          .put("TimestampInvalid", new MediaAPIExceptionFactory.JWPlatformTimestampInvalidException())
-          .put("NonceInvalid", new MediaAPIExceptionFactory.JWPlatformNonceInvalidException())
-          .put("SignatureMissing", new MediaAPIExceptionFactory.JWPlatformSignatureMissingException())
-          .put("SignatureInvalid", new MediaAPIExceptionFactory.JWPlatformSignatureInvalidException())
-          .put("RateLimitExceeded", new MediaAPIExceptionFactory.JWPlatformRateLimitExceededException())
+          .put("Unknown", new JWPlatformUnknownException())
+          .put("NotFound", new JWPlatformNotFoundException())
+          .put("NoMethod", new JWPlatformNoMethodException())
+          .put("NotImplemented", new JWPlatformNotImplementedException())
+          .put("NotSupported", new JWPlatformNotSupportedException())
+          .put("CallFailed", new JWPlatformCallFailedException())
+          .put("CallUnavailable", new JWPlatformCallUnavailableException())
+          .put("CallInvalid", new JWPlatformCallInvalidException())
+          .put("ParameterMissing", new JWPlatformParameterMissingException())
+          .put("ParameterEmpty", new JWPlatformParameterEmptyException())
+          .put("ParameterEncoding", new JWPlatformParameterEncodingException())
+          .put("ParameterInvalid", new JWPlatformParameterInvalidException())
+          .put("PreconditionFailed", new JWPlatformPreconditionFailedException())
+          .put("ItemAlreadyExists", new JWPlatformItemAlreadyExistsException())
+          .put("PermissionDenied", new JWPlatformPermissionDeniedException())
+          .put("Database", new JWPlatformDatabaseException())
+          .put("Integrity", new JWPlatformIntegrityException())
+          .put("DigestMissing", new JWPlatformDigestMissingException())
+          .put("DigestInvalid", new JWPlatformDigestInvalidException())
+          .put("FileUploadFailed", new JWPlatformFileUploadFailedException())
+          .put("FileSizeMissing", new JWPlatformFileSizeMissingException())
+          .put("FileSizeInvalid", new JWPlatformFileSizeInvalidException())
+          .put("Internal", new JWPlatformInternalException())
+          .put("ApiKeyMissing", new JWPlatformApiKeyMissingException())
+          .put("ApiKeyInvalid", new JWPlatformApiKeyInvalidException())
+          .put("TimestampMissing", new JWPlatformTimestampMissingException())
+          .put("TimestampInvalid", new JWPlatformTimestampInvalidException())
+          .put("NonceInvalid", new JWPlatformNonceInvalidException())
+          .put("SignatureMissing", new JWPlatformSignatureMissingException())
+          .put("SignatureInvalid", new JWPlatformSignatureInvalidException())
+          .put("RateLimitExceeded", new JWPlatformRateLimitExceededException())
           .build();
 
   /**
@@ -48,147 +48,12 @@ public class MediaAPIExceptionFactory {
    * @param message - error message
    * @throws JWPlatformException - JWPlatform API returned exception
    */
-  public static void throwJWPlatformException(final String errorType, final String message) throws JWPlatformException {
+  public static void throwJWPlatformException(final String errorType, final String message)
+          throws JWPlatformException {
     final JWPlatformException exception =
             exceptions.containsKey(errorType) ? exceptions.get(errorType) : exceptions.get("Unknown");
     exception.initCause(new JWPlatformException(message));
 
     throw exception;
-  }
-
-  /** Class for an unknown exception. */
-  public static class JWPlatformUnknownException extends JWPlatformException {
-
-    public JWPlatformUnknownException(){
-    }
-
-    /**
-     * Instance of an UnknownException.
-     *
-     * @param message the exception message
-     */
-    public JWPlatformUnknownException(final String message) {
-      super(message);
-    }
-  }
-
-  /** Class for an not found exception. */
-  public static class JWPlatformNotFoundException extends JWPlatformException {
-  }
-
-  /** Class for a no method exception. */
-  public static class JWPlatformNoMethodException extends JWPlatformException {
-  }
-
-  /** Class for a not implemented exception. */
-  public static class JWPlatformNotImplementedException extends JWPlatformException {
-  }
-
-  /** Class for a not supported exception. */
-  public static class JWPlatformNotSupportedException extends JWPlatformException {
-  }
-
-  /** Class for a call failed exception. */
-  public static class JWPlatformCallFailedException extends JWPlatformException {
-  }
-
-  /** Class for a call unavailable exception. */
-  public static class JWPlatformCallUnavailableException extends JWPlatformException {
-  }
-
-  /** Class for a call invalid exception. */
-  public static class JWPlatformCallInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a parameter missing exception. */
-  public static class JWPlatformParameterMissingException extends JWPlatformException {
-  }
-
-  /** Class for a parameter empty exception. */
-  public static class JWPlatformParameterEmptyException extends JWPlatformException {
-  }
-
-  /** Class for a parameter encoding exception. */
-  public static class JWPlatformParameterEncodingException extends JWPlatformException {
-  }
-
-  /** Class for a parameter invalid exception. */
-  public static class JWPlatformParameterInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a precondition failed exception. */
-  public static class JWPlatformPreconditionFailedException extends JWPlatformException {
-  }
-
-  /** Class for an item already exists exception. */
-  public static class JWPlatformItemAlreadyExistsException extends JWPlatformException {
-  }
-
-  /** Class for a permission denied exception. */
-  public static class JWPlatformPermissionDeniedException extends JWPlatformException {
-  }
-
-  /** Class for a database exception. */
-  public static class JWPlatformDatabaseException extends JWPlatformException {
-  }
-
-  /** Class for an integrity exception. */
-  public static class JWPlatformIntegrityException extends JWPlatformException {
-  }
-
-  /** Class for a digest missing exception. */
-  public static class JWPlatformDigestMissingException extends JWPlatformException {
-  }
-
-  /** Class for a digest invalid exception. */
-  public static class JWPlatformDigestInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a file upload failed exception. */
-  public static class JWPlatformFileUploadFailedException extends JWPlatformException {
-  }
-
-  /** Class for a file size missing exception. */
-  public static class JWPlatformFileSizeMissingException extends JWPlatformException {
-  }
-
-  /** Class for a file size invalid exception. */
-  public static class JWPlatformFileSizeInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a internal exception. */
-  public static class JWPlatformInternalException extends JWPlatformException {
-  }
-
-  /** Class for an api key missing exception. */
-  public static class JWPlatformApiKeyMissingException extends JWPlatformException {
-  }
-
-  /** Class for an api key invalid exception. */
-  public static class JWPlatformApiKeyInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a timestamp missing exception. */
-  public static class JWPlatformTimestampMissingException extends JWPlatformException {
-  }
-
-  /** Class for a timestamp invalid exception. */
-  public static class JWPlatformTimestampInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a nonce invalid exception. */
-  public static class JWPlatformNonceInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a signature missing exception. */
-  public static class JWPlatformSignatureMissingException extends JWPlatformException {
-  }
-
-  /** Class for a signature invalid exception. */
-  public static class JWPlatformSignatureInvalidException extends JWPlatformException {
-  }
-
-  /** Class for a rate limit exceeded exception. */
-  public static class JWPlatformRateLimitExceededException extends JWPlatformException {
   }
 }

--- a/src/test/java/com/jwplayer/jwplatform/TestJWPlatformClient.java
+++ b/src/test/java/com/jwplayer/jwplatform/TestJWPlatformClient.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-import com.jwplayer.jwplatform.exception.MediaAPIExceptionFactory;
+import com.jwplayer.jwplatform.exception.JWPlatformUnknownException;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
@@ -69,7 +69,7 @@ public class TestJWPlatformClient {
     }
   }
 
-  @Test(expected = MediaAPIExceptionFactory.JWPlatformUnknownException.class)
+  @Test(expected = JWPlatformUnknownException.class)
   public void testRequestNon200ResponseUnknownException() throws Exception {
     final JSONObject expectedResponse = new JSONObject();
     final JWPlatformClient mediaAPIClient = JWPlatformClient.create(apiKey, apiSecret);
@@ -88,7 +88,7 @@ public class TestJWPlatformClient {
     mediaAPIClient.request(path);
   }
 
-  @Test(expected = MediaAPIExceptionFactory.JWPlatformUnknownException.class)
+  @Test(expected = JWPlatformUnknownException.class)
   public void testRequestUnirestException() throws Exception {
     final JWPlatformClient mediaAPIClient = JWPlatformClient.create(apiKey, apiSecret);
     final GetRequest getRequest = PowerMockito.mock(GetRequest.class);

--- a/src/test/java/com/jwplayer/jwplatform/TestJWPlatformClientExceptions.java
+++ b/src/test/java/com/jwplayer/jwplatform/TestJWPlatformClientExceptions.java
@@ -5,7 +5,36 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-import com.jwplayer.jwplatform.exception.MediaAPIExceptionFactory;
+import com.jwplayer.jwplatform.exception.JWPlatformApiKeyInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformApiKeyMissingException;
+import com.jwplayer.jwplatform.exception.JWPlatformCallFailedException;
+import com.jwplayer.jwplatform.exception.JWPlatformCallInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformCallUnavailableException;
+import com.jwplayer.jwplatform.exception.JWPlatformDatabaseException;
+import com.jwplayer.jwplatform.exception.JWPlatformDigestInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformDigestMissingException;
+import com.jwplayer.jwplatform.exception.JWPlatformFileSizeInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformFileSizeMissingException;
+import com.jwplayer.jwplatform.exception.JWPlatformFileUploadFailedException;
+import com.jwplayer.jwplatform.exception.JWPlatformIntegrityException;
+import com.jwplayer.jwplatform.exception.JWPlatformInternalException;
+import com.jwplayer.jwplatform.exception.JWPlatformItemAlreadyExistsException;
+import com.jwplayer.jwplatform.exception.JWPlatformNoMethodException;
+import com.jwplayer.jwplatform.exception.JWPlatformNonceInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformNotFoundException;
+import com.jwplayer.jwplatform.exception.JWPlatformNotImplementedException;
+import com.jwplayer.jwplatform.exception.JWPlatformNotSupportedException;
+import com.jwplayer.jwplatform.exception.JWPlatformParameterEmptyException;
+import com.jwplayer.jwplatform.exception.JWPlatformParameterEncodingException;
+import com.jwplayer.jwplatform.exception.JWPlatformParameterInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformParameterMissingException;
+import com.jwplayer.jwplatform.exception.JWPlatformPermissionDeniedException;
+import com.jwplayer.jwplatform.exception.JWPlatformPreconditionFailedException;
+import com.jwplayer.jwplatform.exception.JWPlatformRateLimitExceededException;
+import com.jwplayer.jwplatform.exception.JWPlatformSignatureInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformSignatureMissingException;
+import com.jwplayer.jwplatform.exception.JWPlatformTimestampInvalidException;
+import com.jwplayer.jwplatform.exception.JWPlatformTimestampMissingException;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
@@ -38,36 +67,36 @@ public class TestJWPlatformClientExceptions {
     public static Iterable<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
-                        {"NotFoundError", MediaAPIExceptionFactory.JWPlatformNotFoundException.class},
-                        {"NoMethod", MediaAPIExceptionFactory.JWPlatformNoMethodException.class},
-                        {"NotImplemented", MediaAPIExceptionFactory.JWPlatformNotImplementedException.class},
-                        {"NotSupported", MediaAPIExceptionFactory.JWPlatformNotSupportedException.class},
-                        {"CallFailed", MediaAPIExceptionFactory.JWPlatformCallFailedException.class},
-                        {"CallUnavailable", MediaAPIExceptionFactory.JWPlatformCallUnavailableException.class},
-                        {"CallInvalid", MediaAPIExceptionFactory.JWPlatformCallInvalidException.class},
-                        {"ParameterMissing", MediaAPIExceptionFactory.JWPlatformParameterMissingException.class},
-                        {"ParameterEmpty", MediaAPIExceptionFactory.JWPlatformParameterEmptyException.class},
-                        {"ParameterEncoding", MediaAPIExceptionFactory.JWPlatformParameterEncodingException.class},
-                        {"ParameterInvalid", MediaAPIExceptionFactory.JWPlatformParameterInvalidException.class},
-                        {"PreconditionFailed", MediaAPIExceptionFactory.JWPlatformPreconditionFailedException.class},
-                        {"ItemAlreadyExists", MediaAPIExceptionFactory.JWPlatformItemAlreadyExistsException.class},
-                        {"PermissionDenied", MediaAPIExceptionFactory.JWPlatformPermissionDeniedException.class},
-                        {"Database", MediaAPIExceptionFactory.JWPlatformDatabaseException.class},
-                        {"Integrity", MediaAPIExceptionFactory.JWPlatformIntegrityException.class},
-                        {"DigestMissing", MediaAPIExceptionFactory.JWPlatformDigestMissingException.class},
-                        {"DigestInvalid", MediaAPIExceptionFactory.JWPlatformDigestInvalidException.class},
-                        {"FileUploadFailed", MediaAPIExceptionFactory.JWPlatformFileUploadFailedException.class},
-                        {"FileSizeMissing", MediaAPIExceptionFactory.JWPlatformFileSizeMissingException.class},
-                        {"FileSizeInvalid", MediaAPIExceptionFactory.JWPlatformFileSizeInvalidException.class},
-                        {"Internal", MediaAPIExceptionFactory.JWPlatformInternalException.class},
-                        {"ApiKeyMissing", MediaAPIExceptionFactory.JWPlatformApiKeyMissingException.class},
-                        {"ApiKeyInvalid", MediaAPIExceptionFactory.JWPlatformApiKeyInvalidException.class},
-                        {"TimestampMissing", MediaAPIExceptionFactory.JWPlatformTimestampMissingException.class},
-                        {"TimestampInvalid", MediaAPIExceptionFactory.JWPlatformTimestampInvalidException.class},
-                        {"NonceInvalid", MediaAPIExceptionFactory.JWPlatformNonceInvalidException.class},
-                        {"SignatureMissing", MediaAPIExceptionFactory.JWPlatformSignatureMissingException.class},
-                        {"SignatureInvalid", MediaAPIExceptionFactory.JWPlatformSignatureInvalidException.class},
-                        {"RateLimitExceeded", MediaAPIExceptionFactory.JWPlatformRateLimitExceededException.class}
+                        {"NotFoundError", JWPlatformNotFoundException.class},
+                        {"NoMethod", JWPlatformNoMethodException.class},
+                        {"NotImplemented", JWPlatformNotImplementedException.class},
+                        {"NotSupported", JWPlatformNotSupportedException.class},
+                        {"CallFailed", JWPlatformCallFailedException.class},
+                        {"CallUnavailable", JWPlatformCallUnavailableException.class},
+                        {"CallInvalid", JWPlatformCallInvalidException.class},
+                        {"ParameterMissing", JWPlatformParameterMissingException.class},
+                        {"ParameterEmpty", JWPlatformParameterEmptyException.class},
+                        {"ParameterEncoding", JWPlatformParameterEncodingException.class},
+                        {"ParameterInvalid", JWPlatformParameterInvalidException.class},
+                        {"PreconditionFailed", JWPlatformPreconditionFailedException.class},
+                        {"ItemAlreadyExists", JWPlatformItemAlreadyExistsException.class},
+                        {"PermissionDenied", JWPlatformPermissionDeniedException.class},
+                        {"Database", JWPlatformDatabaseException.class},
+                        {"Integrity", JWPlatformIntegrityException.class},
+                        {"DigestMissing", JWPlatformDigestMissingException.class},
+                        {"DigestInvalid", JWPlatformDigestInvalidException.class},
+                        {"FileUploadFailed", JWPlatformFileUploadFailedException.class},
+                        {"FileSizeMissing", JWPlatformFileSizeMissingException.class},
+                        {"FileSizeInvalid", JWPlatformFileSizeInvalidException.class},
+                        {"Internal", JWPlatformInternalException.class},
+                        {"ApiKeyMissing", JWPlatformApiKeyMissingException.class},
+                        {"ApiKeyInvalid", JWPlatformApiKeyInvalidException.class},
+                        {"TimestampMissing", JWPlatformTimestampMissingException.class},
+                        {"TimestampInvalid", JWPlatformTimestampInvalidException.class},
+                        {"NonceInvalid", JWPlatformNonceInvalidException.class},
+                        {"SignatureMissing", JWPlatformSignatureMissingException.class},
+                        {"SignatureInvalid", JWPlatformSignatureInvalidException.class},
+                        {"RateLimitExceeded", JWPlatformRateLimitExceededException.class}
                 });
     }
 


### PR DESCRIPTION
This PR accomplishes a few features:

- _Adds support for POST requests_. Previously, only GET requests were supported. Because we currently do not wrap each endpoint in a function, it is up to the user to provide not only the path but the correct HTTP method as well. This also means we need to support both query params and body params. I followed the design of the [JWPlatform Python library ](https://github.com/jwplayer/jwplatform-py/blob/master/jwplatform/resource.py#L39) and use a boolean flag for this.
- _Refactors the exception factory_. Because the exceptions we needed classes, the stack trace was non-standard. I've broken them out into individual classes here. No other change in behavior.
- _README updates_. Adds an example on file upload.