### PR TITLE
Stop using nested exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,28 @@
+## 0.4.0
+
+* Stop using nested exception handling
+* Bump junit dependency to v4.13 for CVE patch
+
 ## 0.3.1
+
 * Javadoc updates
 
 ## 0.3.0
+
 * Security upgrade of puppycrawl
 * Add param for headers to requests() and upload()
 * Bugfix the Exception Factory
 
 ## 0.2.0
+
 * Add support for POST request endpoints.
-* Refactor exception handling such that exceptions are no longer nested classes of the factory. _This is a breaking change._
+* Refactor exception handling such that exceptions are no longer nested classes of the factory. _This is a breaking
+  change._
 
 ## 0.1.0
+
 * Initial version of the client.
 
 ## 0.0.0
+
 * Initial test version of the client.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.jwplayer</groupId>
   <artifactId>jwplatform</artifactId>
-  <version>0.3.1</version>
+  <version>0.4.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <unirest.version>1.4.9</unirest.version>
         <!-- test dependencies versions -->
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13</junit.version>
         <powermock-module-junit4.version>1.6.2</powermock-module-junit4.version>
         <powermock-api-mockito.version>1.6.2</powermock-api-mockito.version>
         <jacoco-agent-runtime>0.8.1</jacoco-agent-runtime>

--- a/src/main/java/com/jwplayer/jwplatform/JWPlatformClient.java
+++ b/src/main/java/com/jwplayer/jwplatform/JWPlatformClient.java
@@ -35,7 +35,7 @@ import org.json.XML;
  * https://developer.jwplayer.com/jw-platform/reference/v1/index.html
  *
  * <p>Example:
- *    JWPlatformClient client = JWPlatformClient.create(apiKey, apiSecret);
+ * JWPlatformClient client = JWPlatformClient.create(apiKey, apiSecret);
  */
 public class JWPlatformClient {
 
@@ -47,8 +47,8 @@ public class JWPlatformClient {
    * Instantiate a new {@code JWPlatformClient} instance.
    *
    * @param apiSecret - your api key
-   * @param apiKey - your api secret
-   * @param host - url for the Media API
+   * @param apiKey    - your api secret
+   * @param host      - url for the Media API
    */
   private JWPlatformClient(final String apiKey, final String apiSecret, final String host) {
     this.apiKey = apiKey;
@@ -98,10 +98,10 @@ public class JWPlatformClient {
    * @param stringToEncode - the {@code String} to be URL Encoded
    * @return - JW Platform API compliant encoded {@code String}
    * @throws JWPlatformException - an exception occurred trying to encode the requested
-   *     {@code String}
+   *                             {@code String}
    */
   private String encodeStringForJWPlatformAPI(final String stringToEncode)
-          throws JWPlatformException {
+      throws JWPlatformException {
     try {
       final String encodedValue = URLEncoder.encode(stringToEncode, "utf-8");
 
@@ -109,7 +109,7 @@ public class JWPlatformClient {
       return encodedValue.replace("%7E", "~").replace("*", "%2A").replace("+", "%20");
     } catch (final UnsupportedEncodingException e) {
       throw new JWPlatformUnknownException(
-              String.format("Exception thrown encoding URL parameter %s", e.toString()));
+          String.format("Exception thrown encoding URL parameter %s", e.toString()));
     }
   }
 
@@ -119,18 +119,18 @@ public class JWPlatformClient {
    * error message.
    *
    * @param statusCode - the response status code
-   * @param response - a {@code JSONObject} object with the API response block
+   * @param response   - a {@code JSONObject} object with the API response block
    * @throws JWPlatformException - API returned an exception
    */
   private void checkForNon200Response(final int statusCode, final JSONObject response)
-          throws JWPlatformException {
+      throws JWPlatformException {
     if (statusCode != 200) {
       try {
         MediaAPIExceptionFactory.throwJWPlatformException(
-                StringUtils.stripEnd(response.getString("code"), "Error"), response.toString());
+            StringUtils.stripEnd(response.getString("code"), "Error"), response.toString());
       } catch (final JSONException e) {
         throw new JWPlatformUnknownException(
-                String.format("Unknown JSONException thrown: %s", e.toString()));
+            String.format("Unknown JSONException thrown: %s", e.toString()));
       }
     }
   }
@@ -138,7 +138,7 @@ public class JWPlatformClient {
   /**
    * Generates fully formed URL for api request.
    *
-   * @param path - endpoint to be used in API request which includes a leading slash (ie /my/path not my/path)
+   * @param path   - endpoint to be used in API request which includes a leading slash (ie /my/path not my/path)
    * @param params - Parameters to be included in the request
    * @return - Fully formed request URL for an API request with api signature
    * @throws JWPlatformException - an exception occurred during encoding
@@ -173,20 +173,20 @@ public class JWPlatformClient {
   /**
    * Upload a video file from the local file system.
    *
-   * @param uploadPath - the fully constructed upload url which includes a leading slash (ie /my/path not my/path)
+   * @param uploadPath    - the fully constructed upload url which includes a leading slash (ie /my/path not my/path)
    * @param localFilePath - the path to the video file on the local file system
-   * @param headers - Map of headers to add to the request
+   * @param headers       - Map of headers to add to the request
    * @return - JSON response from JW Platform API
    * @throws JWPlatformException - API returned an exception
    */
   private JSONObject uploadVideo(final String uploadPath, final String localFilePath, final Map<String, String> headers)
-          throws JWPlatformException {
+      throws JWPlatformException {
     JSONObject response;
     try {
       HttpResponse<InputStream> r = Unirest.post(uploadPath)
-              .headers(headers)
-              .field("file", new File(localFilePath))
-              .asBinary();
+          .headers(headers)
+          .field("file", new File(localFilePath))
+          .asBinary();
 
       final Reader reader = new InputStreamReader(r.getBody());
       response = XML.toJSONObject(CharStreams.toString(reader));
@@ -194,7 +194,7 @@ public class JWPlatformClient {
       checkForNon200Response(r.getStatus(), response.getJSONObject("response"));
     } catch (final UnirestException | IOException e) {
       throw new JWPlatformUnknownException(
-              String.format("Non-JSON response from server: %s", e.toString()));
+          String.format("Non-JSON response from server: %s", e.toString()));
     }
 
     return response;
@@ -211,7 +211,7 @@ public class JWPlatformClient {
    * see {@link #request(String, Map, boolean, String)}
    */
   public JSONObject request(final String path, final Map<String, String> params)
-          throws JWPlatformException {
+      throws JWPlatformException {
     return this.request(path, params, false, "Get", new HashMap<>());
   }
 
@@ -226,7 +226,8 @@ public class JWPlatformClient {
   /**
    * see {@link #request(String, Map, boolean, String)}
    */
-  public JSONObject request(final String path, final Map<String, String> params, final boolean isBodyParams, final String requestType)
+  public JSONObject request(final String path, final Map<String, String> params, final boolean isBodyParams,
+                            final String requestType)
       throws JWPlatformException {
     return this.request(path, params, isBodyParams, requestType, new HashMap<>());
   }
@@ -237,26 +238,18 @@ public class JWPlatformClient {
    * <p>This function generates an API signature, makes request to JWPlatform API and returns
    * result.
    *
-   * @param path - endpoint to be used in API request which includes a leading slash (ie /my/path not my/path)
-   * @param params - Parameters to be included in the request
+   * @param path         - endpoint to be used in API request which includes a leading slash (ie /my/path not my/path)
+   * @param params       - Parameters to be included in the request
    * @param isBodyParams - Whether the parameters are to be included as query params or in
    *                     the body of the request. This is only relevant for POST requests.
-   * @param requestType - The type of HTTP. Valid values are ["GET", "POST"].
-   * @param headers - Map of headers to add to the request
+   * @param requestType  - The type of HTTP. Valid values are ["GET", "POST"].
+   * @param headers      - Map of headers to add to the request
    * @return - JSON response from JW Platform API
-   * @throws JWPlatformException - JWPlatform API returned an exception. Because we dynamically
-   *     build our exceptions, if you wish to retrieve the error message, you must call it
-   *     from the cause, not the exception directly. The exception's message will be {@code null}.
-   *
-   *     Example: this will be {@code null}
-   *         {@code e.getMessage()}
-   *
-   *     Example: this will contain error message
-   *         {@code e.getCause().getMessage()}
+   * @throws JWPlatformException - JWPlatform API returned an exception.
    */
   public JSONObject request(final String path, final Map<String, String> params,
                             final boolean isBodyParams, final String requestType, final Map<String, String> headers)
-          throws JWPlatformException {
+      throws JWPlatformException {
     final String requestUrl;
     final HttpResponse<JsonNode> response;
 
@@ -284,7 +277,7 @@ public class JWPlatformClient {
       return responseBlock;
     } catch (final UnirestException e) {
       throw new JWPlatformUnknownException(
-              String.format("Non-JSON response from server: %s", e.toString()));
+          String.format("Non-JSON response from server: %s", e.toString()));
     }
   }
 
@@ -300,21 +293,14 @@ public class JWPlatformClient {
    * Upload a video file for a video created with `sourcetype: file`.
    *
    * @param videosCreateResponse - the response object from a '/videos/create' API call.
-   * @param localFilePath - path to the video file on the local file system.
-   * @param headers - map of headers for the request
+   * @param localFilePath        - path to the video file on the local file system.
+   * @param headers              - map of headers for the request
    * @return - JSON response from JW Platform API
-   * @throws JWPlatformException - JWPlatform API returned an exception. Because we dynamically
-   *     build our exceptions, if you wish to retrieve the error message, you must call it
-   *     from the cause, not the exception directly. The exception's message will be {@code null}.
-   *
-   *     Example: this will be {@code null}
-   *         {@code e.getMessage()}
-   *
-   *     Example: this will contain error message
-   *         {@code e.getCause().getMessage()}
+   * @throws JWPlatformException - JWPlatform API returned an exception.
    */
-  public JSONObject upload(final JSONObject videosCreateResponse, final String localFilePath, final Map<String, String> headers)
-          throws JWPlatformException {
+  public JSONObject upload(final JSONObject videosCreateResponse, final String localFilePath,
+                           final Map<String, String> headers)
+      throws JWPlatformException {
     final JSONObject link = videosCreateResponse.getJSONObject("link");
     final String path = link.getString("path");
     final String protocol = link.getString("protocol");
@@ -323,7 +309,7 @@ public class JWPlatformClient {
     final String key = query.getString("key");
     final String token = query.getString("token");
     final String uploadUrl =
-            protocol + "://" + address + path + "?api_format=xml&key=" + key + "&token=" + token;
+        protocol + "://" + address + path + "?api_format=xml&key=" + key + "&token=" + token;
 
     return this.upload(uploadUrl, localFilePath, headers);
   }
@@ -331,20 +317,12 @@ public class JWPlatformClient {
   /**
    * Upload a video file for a video created with `sourcetype: file`.
    *
-   * @param uploadPath - the fully constructed upload url. Refer to the JWPlatform documentation for
-   *     instructions on how to build the url
+   * @param uploadPath    - the fully constructed upload url. Refer to the JWPlatform documentation for
+   *                      instructions on how to build the url
    * @param localFilePath - path to the video file on the local file system.
-   * @param headers - map of headers for the request
+   * @param headers       - map of headers for the request
    * @return - JSON response from JW Platform API
-   * @throws JWPlatformException - JWPlatform API returned an exception. Because we dynamically
-   *     build our exceptions, if you wish to retrieve the error message, you must call it
-   *     from the cause, not the exception directly. The exception's message will be {@code null}.
-   *
-   *     Example: this will be {@code null}
-   *         {@code e.getMessage()}
-   *
-   *     Example: this will contain error message
-   *         {@code e.getCause().getMessage()}
+   * @throws JWPlatformException - JWPlatform API returned an exception.
    */
   public JSONObject upload(final String uploadPath, final String localFilePath, final Map<String, String> headers)
       throws JWPlatformException {

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformApiKeyInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an ApiKeyInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformApiKeyInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformApiKeyMissingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformApiKeyMissingException extends JWPlatformException {
+
+  /**
+   * Instance of an ApiKeyMissingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformApiKeyMissingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallFailedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallFailedException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformCallFailedException extends JWPlatformException {
+
+  /**
+   * Instance of an CallFailedException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformCallFailedException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformCallInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an CallInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformCallInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallUnavailableException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformCallUnavailableException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformCallUnavailableException extends JWPlatformException {
+
+  /**
+   * Instance of an CallUnavailableException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformCallUnavailableException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDatabaseException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDatabaseException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformDatabaseException extends JWPlatformException {
+
+  /**
+   * Instance of an DatabaseException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformDatabaseException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformDigestInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an DigestInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformDigestInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformDigestMissingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformDigestMissingException extends JWPlatformException {
+
+  /**
+   * Instance of an DigestMissingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformDigestMissingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformException.java
@@ -1,17 +1,16 @@
 package com.jwplayer.jwplatform.exception;
 
-/** Base class for JWPlatform Exceptions. */
+/**
+ * Base class for JWPlatform Exceptions.
+ */
 public class JWPlatformException extends Exception {
 
-    public JWPlatformException() {
-    }
-
-    /**
-     * Instance of an UnknownException.
-     *
-     * @param message the exception message
-     */
-    public JWPlatformException(final String message) {
-        super(message);
-    }
+  /**
+   * Instance of an UnknownException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformFileSizeInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an FileSizeInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformFileSizeInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileSizeMissingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformFileSizeMissingException extends JWPlatformException {
+
+  /**
+   * Instance of an FileSizeMissingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformFileSizeMissingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileUploadFailedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformFileUploadFailedException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformFileUploadFailedException extends JWPlatformException {
+
+  /**
+   * Instance of an FileUploadFailedException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformFileUploadFailedException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformIntegrityException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformIntegrityException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformIntegrityException extends JWPlatformException {
+
+  /**
+   * Instance of an IntegrityException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformIntegrityException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformInternalException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformInternalException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformInternalException extends JWPlatformException {
+
+  /**
+   * Instance of an InternalException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformInternalException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformItemAlreadyExistsException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformItemAlreadyExistsException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformItemAlreadyExistsException extends JWPlatformException {
+
+  /**
+   * Instance of an ItemAlreadyExistsException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformItemAlreadyExistsException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNoMethodException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNoMethodException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformNoMethodException extends JWPlatformException {
+
+  /**
+   * Instance of an NoMethodException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformNoMethodException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNonceInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNonceInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformNonceInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an NonceInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformNonceInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotFoundException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotFoundException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformNotFoundException extends JWPlatformException {
+
+  /**
+   * Instance of an NotFoundException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformNotFoundException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotImplementedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotImplementedException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformNotImplementedException extends JWPlatformException {
+
+  /**
+   * Instance of an NotImplementedException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformNotImplementedException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotSupportedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformNotSupportedException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformNotSupportedException extends JWPlatformException {
+
+  /**
+   * Instance of an NotSupportedException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformNotSupportedException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEmptyException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEmptyException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformParameterEmptyException extends JWPlatformException {
+
+  /**
+   * Instance of an ParameterEmptyException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformParameterEmptyException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEncodingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterEncodingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformParameterEncodingException extends JWPlatformException {
+
+  /**
+   * Instance of an ParameterEncodingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformParameterEncodingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformParameterInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an ParameterInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformParameterInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformParameterMissingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformParameterMissingException extends JWPlatformException {
+
+  /**
+   * Instance of an ParameterMissingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformParameterMissingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPermissionDeniedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPermissionDeniedException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformPermissionDeniedException extends JWPlatformException {
+
+  /**
+   * Instance of an PermissionDeniedException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformPermissionDeniedException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPreconditionFailedException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformPreconditionFailedException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformPreconditionFailedException extends JWPlatformException {
+
+  /**
+   * Instance of an PreconditionFailedException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformPreconditionFailedException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformRateLimitExceededException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformRateLimitExceededException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformRateLimitExceededException extends JWPlatformException {
+
+  /**
+   * Instance of an RateLimitExceededException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformRateLimitExceededException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformSignatureInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an SignatureInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformSignatureInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformSignatureMissingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformSignatureMissingException extends JWPlatformException {
+
+  /**
+   * Instance of an SignatureMissingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformSignatureMissingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampInvalidException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampInvalidException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformTimestampInvalidException extends JWPlatformException {
+
+  /**
+   * Instance of an TimestampInvalidException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformTimestampInvalidException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampMissingException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformTimestampMissingException.java
@@ -1,4 +1,13 @@
 package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformTimestampMissingException extends JWPlatformException {
+
+  /**
+   * Instance of an TimestampMissingException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformTimestampMissingException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformUnknownException.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/JWPlatformUnknownException.java
@@ -2,15 +2,12 @@ package com.jwplayer.jwplatform.exception;
 
 public class JWPlatformUnknownException extends JWPlatformException {
 
-    public JWPlatformUnknownException(){
-    }
-
-    /**
-     * Instance of an UnknownException.
-     *
-     * @param message the exception message
-     */
-    public JWPlatformUnknownException(final String message) {
-        super(message);
-    }
+  /**
+   * Instance of an UnknownException.
+   *
+   * @param message the exception message
+   */
+  public JWPlatformUnknownException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/jwplayer/jwplatform/exception/MediaAPIExceptionFactory.java
+++ b/src/main/java/com/jwplayer/jwplatform/exception/MediaAPIExceptionFactory.java
@@ -1,65 +1,83 @@
 package com.jwplayer.jwplatform.exception;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-
-/** Factory for creating and throwing JWPlatform Exceptions. */
+/**
+ * Factory for creating and throwing JWPlatform Exceptions.
+ */
 public class MediaAPIExceptionFactory {
-
-  private static final Map<String, Class> exceptions = ImmutableMap.<String, Class>builder()
-          .put("Unknown", JWPlatformUnknownException.class)
-          .put("NotFound", JWPlatformNotFoundException.class)
-          .put("NoMethod", JWPlatformNoMethodException.class)
-          .put("NotImplemented", JWPlatformNotImplementedException.class)
-          .put("NotSupported", JWPlatformNotSupportedException.class)
-          .put("CallFailed", JWPlatformCallFailedException.class)
-          .put("CallUnavailable", JWPlatformCallUnavailableException.class)
-          .put("CallInvalid", JWPlatformCallInvalidException.class)
-          .put("ParameterMissing", JWPlatformParameterMissingException.class)
-          .put("ParameterEmpty", JWPlatformParameterEmptyException.class)
-          .put("ParameterEncoding", JWPlatformParameterEncodingException.class)
-          .put("ParameterInvalid", JWPlatformParameterInvalidException.class)
-          .put("PreconditionFailed", JWPlatformPreconditionFailedException.class)
-          .put("ItemAlreadyExists", JWPlatformItemAlreadyExistsException.class)
-          .put("PermissionDenied", JWPlatformPermissionDeniedException.class)
-          .put("Database", JWPlatformDatabaseException.class)
-          .put("Integrity", JWPlatformIntegrityException.class)
-          .put("DigestMissing", JWPlatformDigestMissingException.class)
-          .put("DigestInvalid", JWPlatformDigestInvalidException.class)
-          .put("FileUploadFailed", JWPlatformFileUploadFailedException.class)
-          .put("FileSizeMissing", JWPlatformFileSizeMissingException.class)
-          .put("FileSizeInvalid", JWPlatformFileSizeInvalidException.class)
-          .put("Internal", JWPlatformInternalException.class)
-          .put("ApiKeyMissing", JWPlatformApiKeyMissingException.class)
-          .put("ApiKeyInvalid", JWPlatformApiKeyInvalidException.class)
-          .put("TimestampMissing", JWPlatformTimestampMissingException.class)
-          .put("TimestampInvalid", JWPlatformTimestampInvalidException.class)
-          .put("NonceInvalid", JWPlatformNonceInvalidException.class)
-          .put("SignatureMissing", JWPlatformSignatureMissingException.class)
-          .put("SignatureInvalid", JWPlatformSignatureInvalidException.class)
-          .put("RateLimitExceeded", JWPlatformRateLimitExceededException.class)
-          .build();
 
   /**
    * A case statement for finding and throwing the appropriate exception give an error from the
    * JWPlatform API.
    *
    * @param errorType - the error type
-   * @param message - error message
+   * @param message   - error message
    * @throws JWPlatformException - JWPlatform API returned exception
    */
-  @SuppressWarnings("unchecked")
   public static void throwJWPlatformException(final String errorType, final String message)
-          throws JWPlatformException {
-    final Class<JWPlatformException> clazz =
-            exceptions.containsKey(errorType) ? exceptions.get(errorType) : exceptions.get("Unknown");
-
-    try {
-      final JWPlatformException exception = clazz.newInstance();
-      exception.initCause(new JWPlatformException(message));
-      throw exception;
-    } catch (InstantiationException | IllegalAccessException e) {
-      throw new JWPlatformUnknownException(message);
+      throws JWPlatformException {
+    switch (errorType) {
+      case "NotFound":
+        throw new JWPlatformNotFoundException(message);
+      case "NoMethod":
+        throw new JWPlatformNoMethodException(message);
+      case "NotImplemented":
+        throw new JWPlatformNotImplementedException(message);
+      case "NotSupported":
+        throw new JWPlatformNotSupportedException(message);
+      case "CallFailed":
+        throw new JWPlatformCallFailedException(message);
+      case "CallUnavailable":
+        throw new JWPlatformCallUnavailableException(message);
+      case "CallInvalid":
+        throw new JWPlatformCallInvalidException(message);
+      case "ParameterMissing":
+        throw new JWPlatformParameterMissingException(message);
+      case "ParameterEmpty":
+        throw new JWPlatformParameterEmptyException(message);
+      case "ParameterEncoding":
+        throw new JWPlatformParameterEncodingException(message);
+      case "ParameterInvalid":
+        throw new JWPlatformParameterInvalidException(message);
+      case "PreconditionFailed":
+        throw new JWPlatformPreconditionFailedException(message);
+      case "ItemAlreadyExists":
+        throw new JWPlatformItemAlreadyExistsException(message);
+      case "PermissionDenied":
+        throw new JWPlatformPermissionDeniedException(message);
+      case "Database":
+        throw new JWPlatformDatabaseException(message);
+      case "Integrity":
+        throw new JWPlatformIntegrityException(message);
+      case "DigestMissing":
+        throw new JWPlatformDigestMissingException(message);
+      case "DigestInvalid":
+        throw new JWPlatformDigestInvalidException(message);
+      case "FileUploadFailed":
+        throw new JWPlatformFileUploadFailedException(message);
+      case "FileSizeMissing":
+        throw new JWPlatformFileSizeMissingException(message);
+      case "FileSizeInvalid":
+        throw new JWPlatformFileSizeInvalidException(message);
+      case "Internal":
+        throw new JWPlatformInternalException(message);
+      case "ApiKeyMissing":
+        throw new JWPlatformApiKeyMissingException(message);
+      case "ApiKeyInvalid":
+        throw new JWPlatformApiKeyInvalidException(message);
+      case "TimestampMissing":
+        throw new JWPlatformTimestampMissingException(message);
+      case "TimestampInvalid":
+        throw new JWPlatformTimestampInvalidException(message);
+      case "NonceInvalid":
+        throw new JWPlatformNonceInvalidException(message);
+      case "SignatureMissing":
+        throw new JWPlatformSignatureMissingException(message);
+      case "SignatureInvalid":
+        throw new JWPlatformSignatureInvalidException(message);
+      case "RateLimitExceeded":
+        throw new JWPlatformRateLimitExceededException(message);
+      default:
+        throw new JWPlatformUnknownException(message);
     }
   }
 }

--- a/src/test/java/com/jwplayer/jwplatform/TestJWPlatformClient.java
+++ b/src/test/java/com/jwplayer/jwplatform/TestJWPlatformClient.java
@@ -2,7 +2,10 @@ package com.jwplayer.jwplatform;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -81,11 +84,11 @@ public class TestJWPlatformClient {
   @SuppressWarnings("unchecked")
   public void testPostRequestWithSpecialCharacterUrlEncoding() throws Exception {
     final HashMap<String, String> params =
-            new HashMap<String, String>() {
-              {
-                put("url", "media.com +!~");
-              }
-            };
+        new HashMap<String, String>() {
+          {
+            put("url", "media.com +!~");
+          }
+        };
     final JSONObject expectedResponse = new JSONObject();
     expectedResponse.put("status", 200);
 

--- a/src/test/java/com/jwplayer/jwplatform/exception/TestJWPlatformClientExceptions.java
+++ b/src/test/java/com/jwplayer/jwplatform/exception/TestJWPlatformClientExceptions.java
@@ -26,69 +26,69 @@ import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 @PrepareForTest({Unirest.class, HttpResponse.class})
 public class TestJWPlatformClientExceptions {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
 
-    @Parameterized.Parameter
-    public String exceptionName;
-    @Parameterized.Parameter(1)
-    public Class expectedException;
+  @Parameterized.Parameter
+  public String exceptionName;
+  @Parameterized.Parameter(1)
+  public Class expectedException;
 
-    @Parameterized.Parameters(name = "{index}: testCorrectJWPlatformExceptionRaised({0})={1}")
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(
-                new Object[][] {
-                        {"NotFoundError", JWPlatformNotFoundException.class},
-                        {"NoMethod", JWPlatformNoMethodException.class},
-                        {"NotImplemented", JWPlatformNotImplementedException.class},
-                        {"NotSupported", JWPlatformNotSupportedException.class},
-                        {"CallFailed", JWPlatformCallFailedException.class},
-                        {"CallUnavailable", JWPlatformCallUnavailableException.class},
-                        {"CallInvalid", JWPlatformCallInvalidException.class},
-                        {"ParameterMissing", JWPlatformParameterMissingException.class},
-                        {"ParameterEmpty", JWPlatformParameterEmptyException.class},
-                        {"ParameterEncoding", JWPlatformParameterEncodingException.class},
-                        {"ParameterInvalid", JWPlatformParameterInvalidException.class},
-                        {"PreconditionFailed", JWPlatformPreconditionFailedException.class},
-                        {"ItemAlreadyExists", JWPlatformItemAlreadyExistsException.class},
-                        {"PermissionDenied", JWPlatformPermissionDeniedException.class},
-                        {"Database", JWPlatformDatabaseException.class},
-                        {"Integrity", JWPlatformIntegrityException.class},
-                        {"DigestMissing", JWPlatformDigestMissingException.class},
-                        {"DigestInvalid", JWPlatformDigestInvalidException.class},
-                        {"FileUploadFailed", JWPlatformFileUploadFailedException.class},
-                        {"FileSizeMissing", JWPlatformFileSizeMissingException.class},
-                        {"FileSizeInvalid", JWPlatformFileSizeInvalidException.class},
-                        {"Internal", JWPlatformInternalException.class},
-                        {"ApiKeyMissing", JWPlatformApiKeyMissingException.class},
-                        {"ApiKeyInvalid", JWPlatformApiKeyInvalidException.class},
-                        {"TimestampMissing", JWPlatformTimestampMissingException.class},
-                        {"TimestampInvalid", JWPlatformTimestampInvalidException.class},
-                        {"NonceInvalid", JWPlatformNonceInvalidException.class},
-                        {"SignatureMissing", JWPlatformSignatureMissingException.class},
-                        {"SignatureInvalid", JWPlatformSignatureInvalidException.class},
-                        {"RateLimitExceeded", JWPlatformRateLimitExceededException.class},
-                        // add twice to test instance conflict
-                        {"RateLimitExceeded", JWPlatformRateLimitExceededException.class}
-                });
-    }
+  @Parameterized.Parameters(name = "{index}: testCorrectJWPlatformExceptionRaised({0})={1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+            {"NotFoundError", JWPlatformNotFoundException.class},
+            {"NoMethod", JWPlatformNoMethodException.class},
+            {"NotImplemented", JWPlatformNotImplementedException.class},
+            {"NotSupported", JWPlatformNotSupportedException.class},
+            {"CallFailed", JWPlatformCallFailedException.class},
+            {"CallUnavailable", JWPlatformCallUnavailableException.class},
+            {"CallInvalid", JWPlatformCallInvalidException.class},
+            {"ParameterMissing", JWPlatformParameterMissingException.class},
+            {"ParameterEmpty", JWPlatformParameterEmptyException.class},
+            {"ParameterEncoding", JWPlatformParameterEncodingException.class},
+            {"ParameterInvalid", JWPlatformParameterInvalidException.class},
+            {"PreconditionFailed", JWPlatformPreconditionFailedException.class},
+            {"ItemAlreadyExists", JWPlatformItemAlreadyExistsException.class},
+            {"PermissionDenied", JWPlatformPermissionDeniedException.class},
+            {"Database", JWPlatformDatabaseException.class},
+            {"Integrity", JWPlatformIntegrityException.class},
+            {"DigestMissing", JWPlatformDigestMissingException.class},
+            {"DigestInvalid", JWPlatformDigestInvalidException.class},
+            {"FileUploadFailed", JWPlatformFileUploadFailedException.class},
+            {"FileSizeMissing", JWPlatformFileSizeMissingException.class},
+            {"FileSizeInvalid", JWPlatformFileSizeInvalidException.class},
+            {"Internal", JWPlatformInternalException.class},
+            {"ApiKeyMissing", JWPlatformApiKeyMissingException.class},
+            {"ApiKeyInvalid", JWPlatformApiKeyInvalidException.class},
+            {"TimestampMissing", JWPlatformTimestampMissingException.class},
+            {"TimestampInvalid", JWPlatformTimestampInvalidException.class},
+            {"NonceInvalid", JWPlatformNonceInvalidException.class},
+            {"SignatureMissing", JWPlatformSignatureMissingException.class},
+            {"SignatureInvalid", JWPlatformSignatureInvalidException.class},
+            {"RateLimitExceeded", JWPlatformRateLimitExceededException.class},
+            // add twice to test instance conflict
+            {"RateLimitExceeded", JWPlatformRateLimitExceededException.class}
+        });
+  }
 
-    @Test
-    public void testCorrectJWPlatformExceptionRaised() throws Exception {
-        exceptionRule.expect(expectedException);
+  @Test
+  public void testCorrectJWPlatformExceptionRaised() throws Exception {
+    exceptionRule.expect(expectedException);
 
-        final JWPlatformClient mediaAPIClient = JWPlatformClient.create("fakeApiKey", "fakeApiSecret");
-        final HttpResponse httpResponse = PowerMockito.mock(HttpResponse.class);
-        final GetRequest getRequest = PowerMockito.mock(GetRequest.class);
-        final JsonNode non200ResponseBody = new JsonNode("{\"code\":\""+ exceptionName + "\"}");
-        mockStatic(Unirest.class);
+    final JWPlatformClient mediaAPIClient = JWPlatformClient.create("fakeApiKey", "fakeApiSecret");
+    final HttpResponse httpResponse = PowerMockito.mock(HttpResponse.class);
+    final GetRequest getRequest = PowerMockito.mock(GetRequest.class);
+    final JsonNode non200ResponseBody = new JsonNode("{\"code\":\"" + exceptionName + "\"}");
+    mockStatic(Unirest.class);
 
-        when(Unirest.get(anyString())).thenReturn(getRequest);
-        when(getRequest.headers(anyMap())).thenReturn(getRequest);
-        when(getRequest.asJson()).thenReturn(httpResponse);
-        when(httpResponse.getStatus()).thenReturn(418);
-        when(httpResponse.getBody()).thenReturn(non200ResponseBody);
+    when(Unirest.get(anyString())).thenReturn(getRequest);
+    when(getRequest.headers(anyMap())).thenReturn(getRequest);
+    when(getRequest.asJson()).thenReturn(httpResponse);
+    when(httpResponse.getStatus()).thenReturn(418);
+    when(httpResponse.getBody()).thenReturn(non200ResponseBody);
 
-        mediaAPIClient.request("/v1/videos/create");
-    }
+    mediaAPIClient.request("/v1/videos/create");
+  }
 }


### PR DESCRIPTION
Previously, we were nesting the actual API exception inside a base exception. This is not very nice for clients to work with. We This PR updates the code to throw the top level exceptions directly.

Also, bumps the version of JUnit for a CVE patch. Checkstyle cleaned up some bad formatting.