### PR TITLE
SERV 11910: Remove extra Bearer string

### DIFF
--- a/src/main/java/com/jwplayer/jwplatform/client/MediaClient.java
+++ b/src/main/java/com/jwplayer/jwplatform/client/MediaClient.java
@@ -35,7 +35,7 @@ public class MediaClient extends JWPlatformClientV2 {
 		this.secret = secret;
 		this.path = "https://api.jwplayer.com/v2/sites/%s/media/";
 		headers = new HashMap<>();
-		headers.put("Authorization", "Bearer " + this.secret);
+		headers.put("Authorization", this.secret);
 		headers.put("accept", "application/json");
 		headers.put("Content-Type", "application/json");
 	}


### PR DESCRIPTION
Per the customer issue in the branch name, we need to remove the extra "Bearer" to get commands against the API working. 